### PR TITLE
Add option to delete command

### DIFF
--- a/nurc/src/command/delete.rs
+++ b/nurc/src/command/delete.rs
@@ -1,0 +1,7 @@
+use clap::Args;
+
+#[derive(Args)]
+pub struct DeleteArgs {
+    #[arg(short, long)]
+    force: bool,
+}

--- a/nurc/src/command/delete.rs
+++ b/nurc/src/command/delete.rs
@@ -2,6 +2,7 @@ use clap::Args;
 
 #[derive(Args)]
 pub struct DeleteArgs {
+    /// Forcibly delete the running container, using SIGKILL signal(7) to stop it first.
     #[arg(short, long)]
     force: bool,
 }

--- a/nurc/src/command/mod.rs
+++ b/nurc/src/command/mod.rs
@@ -1,1 +1,2 @@
 pub mod ps;
+pub mod delete;

--- a/nurc/src/main.rs
+++ b/nurc/src/main.rs
@@ -19,7 +19,7 @@ enum Commands {
     Create,
 
     /// Delete any resources held by the container; often used with detached containers
-    Delete,
+    Delete(command::delete::DeleteArgs),
 
     /// Display container events, such as OOM notifications, CPU, memory, I/O and network statistics
     Events,
@@ -73,7 +73,7 @@ fn main() {
         Commands::Create => {
             println!("'nurc create' was used")
         }
-        Commands::Delete => {
+        Commands::Delete(_) => {
             println!("'nurc delete' was used")
         }
         Commands::Events => {


### PR DESCRIPTION
## Description
Title

## Test Plan
```
% cargo run -- help delete
   Compiling nurc v0.1.0 (/Users/youngmokcho/Projects/nurc/nurc)
    Finished dev [unoptimized + debuginfo] target(s) in 1.59s
     Running `target/debug/nurc help delete`
Delete any resources held by the container; often used with detached containers

Usage: nurc delete [OPTIONS]

Options:
  -f, --force    Forcibly delete the running container, using SIGKILL signal(7) to stop it first
  -h, --help     Print help
  -V, --version  Print version
```